### PR TITLE
Add requirements.txt for python3.6 environment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,16 @@
+aiodns==1.1.1
+aiohttp==2.3.9
+async-timeout==2.0.0
+cchardet==2.1.1
+certifi==2018.1.18
+chardet==3.0.4
+idna==2.6
+multidict==4.1.0
+pycares==2.3.0
+pyzmq==16.0.4
+requests==2.18.4
+twofish==0.3.0
+urllib3==1.22
+uvloop==0.9.1
+yarl==1.1.0
+zmq==0.0.0


### PR DESCRIPTION
This is just to get to the point that we can 'instantiate' a masternode object.

Other networking aspects may need more deps

This includes the extras recommended in AIOHTTP's library installation documentation.

https://aiohttp.readthedocs.io/en/stable/#library-installation

Created this from the following
one-liner in Linux Ubuntu 16.04 with python 3.6:

    $ pip freeze; pip freeze > requirements.txt
    aiodns==1.1.1
    aiohttp==2.3.9
    async-timeout==2.0.0
    cchardet==2.1.1
    certifi==2018.1.18
    chardet==3.0.4
    idna==2.6
    multidict==4.1.0
    pycares==2.3.0
    pyzmq==16.0.4
    requests==2.18.4
    twofish==0.3.0
    urllib3==1.22
    uvloop==0.9.1
    yarl==1.1.0
    zmq==0.0.0