### PR TITLE
Update .gitignore for generated Python pyc & cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,13 @@
+#Virtual Python Environments
 /venv
+
+#Integrated Development Environments
 /.idea
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so


### PR DESCRIPTION
Tired of seeing this in git status? Merge our `gitignorepyc` product today and make rebasing easier

	cilantro/networking/__pycache__/masternode.cpython-36.pyc
	cilantro/networking/__pycache__/witness.cpython-36.pyc
	cilantro/proofs/__pycache__/
	cilantro/proofs/pow/__pycache__/
	cilantro/serialization/__pycache__/
	tests/__pycache__/
	tests/cilantro/__pycache__/
	tests/cilantro/networking/__pycache__/

Regex-ish stuff "inspired" by https://github.com/github/gitignore/blob/master/Python.gitignore