### PR TITLE
Update control flow for find method

### DIFF
--- a/cilantro/proofs/pow/sha.py
+++ b/cilantro/proofs/pow/sha.py
@@ -9,9 +9,8 @@ class SHA3POW(POW):
             h = hashlib.sha3_256()
             s = secrets.token_bytes(16)
             h.update(o + s)
-            if h.digest().hex()[0:3] != '000':
-                break
-        return s.hex()[2:], h.digest().hex()[2:]
+            if h.digest().hex()[0:3] == '000':
+                return s.hex()[2:], h.digest().hex()[2:]
 
     @staticmethod
     def check(o: bytes, proof: str):


### PR DESCRIPTION
Presuming that s.hex() will return a hex representation of the same .token_bytes() output, then what this change does is make it so that the return will only happen if the first 3 hex digits of the digest are '000'.