### PR TITLE
Async queue flush

### DIFF
--- a/cilantro/networking/basenode.py
+++ b/cilantro/networking/basenode.py
@@ -1,10 +1,14 @@
 import asyncio
-import uvloop
 import zmq
 from zmq.asyncio import Context
 
-# Using UV Loop for EventLoop, instead aysncio's event loop
-asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+# Using UV Loop for EventLoop, instead asyncio's event loop
+import sys
+if sys.platform != 'win32':
+    import uvloop
+    asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+
+
 
 
 class BaseNode(object):

--- a/cilantro/networking/masternode.py
+++ b/cilantro/networking/masternode.py
@@ -1,4 +1,3 @@
-import uvloop
 from cilantro.networking.constants import MAX_REQUEST_LENGTH, TX_STATUS, NTP_URL
 from cilantro.transactions.testnet import TestNetTransaction
 from cilantro.networking import BaseNode
@@ -8,7 +7,10 @@ from cilantro.db.masternode.blockchain_driver import BlockchainDriver
 import sys
 import ntplib
 import uuid
-web.asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+import sys
+if sys.platform != 'win32':
+    import uvloop
+    web.asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
 
 
 '''


### PR DESCRIPTION
working async timer method
could be blocking - please test

a) set self.timer = 0 upon initilization
b) fire and forget async call to wait block time (1 second)
c) while not self.timer check queue size and perform consensus if it's >
max
d) after one second the while loop is broken and perform consensus is
performed anyway
e) if consensus is performed with no tx then function return
f) consensus sets timer flag back to 0

need to call process transaction repeatedly while allowing for consensus
(on sepearate process?)