### PR TITLE
Command.execute() is not implemented in reactor_brainstorm.py

### DIFF
--- a/playground/reactor/reactor_brainstorm.py
+++ b/playground/reactor/reactor_brainstorm.py
@@ -227,6 +227,7 @@ class Command(metaclass=CommandMeta):
 
     @classmethod
     def execute(cls, ):
+        raise NotImplementedError  # TODO
 
 
 class AddSubCommand(Command):


### PR DESCRIPTION
A method with no body is a syntax error in Python.

flake8 testing of https://github.com/lamden/cilantro on Python 3.6.3

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__

```
./playground/reactor/reactor_brainstorm.py:232:1: E999 IndentationError: expected an indented block
class AddSubCommand(Command):
^
1     E999 IndentationError: expected an indented block
```