### PR TITLE
Flake8 to find syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ install:
   - pip install -r requirements.txt
   - pip install -r dev-requirements.txt
   - python setup.py develop
+before_script:
+  - pip install flake8  # should be moved into dev-requirements.txt
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script: python ./tests/protocol/statemachine/test_state.py
 notifications:
   webhooks:


### PR DESCRIPTION
Stop the build if there are Python syntax errors or undefined names

Output:
1     E999 IndentationError: expected an indented block
23    F821 undefined name 'lazy_property'
24

https://travis-ci.org/Lamden/cilantro/builds/391568646#L907-L982

__E901,E999,F821,F822,F823__ are the "showstopper" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc.  Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.  This PR therefore recommends a flake8 run of these tests on the entire codebase.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable `name` referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree